### PR TITLE
Feature/lib updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# OS generated files #
+######################
+.DS_Store?
+.DS_Store
+._.DS_Store
+ehthumbs.db
+._*
+Thumbs.db
+
 # Logs
 logs
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgraded Node binary reference from `12.16` to `v16.13.2` in `.nvmrc`
-- LICENSE edits
+- `LICENSE` edits
+- `README.md` edits
 - Beautified `src/helpers/index.js`
 - Beautified `src/index.js`
 - Beautified `examples/ply-model-to-png.js`
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - eslint ^7.1.0 → ^8.6.0
   - mocha ^7.2.0 → ^9.1.3
   - pngjs ^4.0.0 → ^6.0.0
+  - three ^0.115.0 → ^0.125.0
 
 ## [v1.1.10] - 2020-05-29
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Three.js PLY file format loader to use with Node.js
 
 ## Description
-Node.js wrapper for [three.js][THREEJS-github-link] PLYLoader (currently three.js v0.115.0).
+Node.js wrapper for [three.js][THREEJS-github-link] PLYLoader (currently three.js v0.125.0).
 
 Original PLYLoader source code can be found [here][PLYLoader-source-link].
 
@@ -40,8 +40,8 @@ const geometry = plyLoader.parse(fileArrayBuffer);
 An example is present in the examples folder. It will load a PLY file model and output its rendering to a PNG file. It can be run from a shell:
 
 ```bash
-$ npm install
-$ npm run example:cube-to-png
+npm install
+npm run example:cube-to-png
 ```
 
 The output image is going to located in `examples/temp/vertex-colored-cube.png`
@@ -51,14 +51,14 @@ The output image is going to located in `examples/temp/vertex-colored-cube.png`
 They can be run from a shell:
 
 ```bash
-$ npm install
-$ npm test
+npm install
+npm test
 ```
 
 ## Development notes
-Developed with Node v12.16.2
+Developed with Node v16.13.2
 
 [THREEJS-github-link]: https://github.com/mrdoob/three.js
-[PLYLoader-source-link]: https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/PLYLoader.js
+[PLYLoader-source-link]: https://github.com/mrdoob/three.js/blob/r115/examples/js/loaders/PLYLoader.js
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,14 @@
         "eslint": "^8.6.0",
         "mocha": "^9.1.3",
         "pngjs": "^6.0.0",
-        "three": "^0.115.0",
+        "three": "^0.125.0",
         "three-software-renderer": "https://github.com/lanceschi/three-software-renderer.git#feature/projector-update"
       },
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "three": ">=0.115.0"
+        "three": ">=0.125.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1512,9 +1512,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.115.0.tgz",
-      "integrity": "sha512-mAV2Ky3RdcbdSbR9capI+tKLvRldWYxd4151PZTT/o7+U2jh9Is3a4KmnYwzyUAhB2ZA3pXSgCd2DOY4Tj5kow==",
+      "version": "0.125.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
+      "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA==",
       "dev": true
     },
     "node_modules/three-software-renderer": {
@@ -2797,9 +2797,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.115.0.tgz",
-      "integrity": "sha512-mAV2Ky3RdcbdSbR9capI+tKLvRldWYxd4151PZTT/o7+U2jh9Is3a4KmnYwzyUAhB2ZA3pXSgCd2DOY4Tj5kow==",
+      "version": "0.125.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
+      "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA==",
       "dev": true
     },
     "three-software-renderer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,14 @@
         "eslint": "^8.6.0",
         "mocha": "^9.1.3",
         "pngjs": "^6.0.0",
-        "three": "^0.112.0",
+        "three": "^0.115.0",
         "three-software-renderer": "https://github.com/lanceschi/three-software-renderer.git#feature/projector-update"
       },
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
-        "three": ">=0.112.0"
+        "three": ">=0.115.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1512,9 +1512,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.112.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.112.1.tgz",
-      "integrity": "sha512-8I0O74hiYtKl3LgDNcPJbBGOlpekbcJ6fJnImmW3mFdeUFJ2H9Y3/UuUSW2sBdjrIlCM0gvOkaTEFlofO900TQ==",
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.115.0.tgz",
+      "integrity": "sha512-mAV2Ky3RdcbdSbR9capI+tKLvRldWYxd4151PZTT/o7+U2jh9Is3a4KmnYwzyUAhB2ZA3pXSgCd2DOY4Tj5kow==",
       "dev": true
     },
     "node_modules/three-software-renderer": {
@@ -2797,9 +2797,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.112.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.112.1.tgz",
-      "integrity": "sha512-8I0O74hiYtKl3LgDNcPJbBGOlpekbcJ6fJnImmW3mFdeUFJ2H9Y3/UuUSW2sBdjrIlCM0gvOkaTEFlofO900TQ==",
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.115.0.tgz",
+      "integrity": "sha512-mAV2Ky3RdcbdSbR9capI+tKLvRldWYxd4151PZTT/o7+U2jh9Is3a4KmnYwzyUAhB2ZA3pXSgCd2DOY4Tj5kow==",
       "dev": true
     },
     "three-software-renderer": {

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "eslint": "^8.6.0",
     "mocha": "^9.1.3",
     "pngjs": "^6.0.0",
-    "three": "^0.115.0",
+    "three": "^0.125.0",
     "three-software-renderer": "https://github.com/lanceschi/three-software-renderer.git#feature/projector-update"
   },
   "peerDependencies": {
-    "three": ">=0.115.0"
+    "three": ">=0.125.0"
   },
   "dependencies": {},
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "eslint": "^8.6.0",
     "mocha": "^9.1.3",
     "pngjs": "^6.0.0",
-    "three": "^0.112.0",
+    "three": "^0.115.0",
     "three-software-renderer": "https://github.com/lanceschi/three-software-renderer.git#feature/projector-update"
   },
   "peerDependencies": {
-    "three": ">=0.112.0"
+    "three": ">=0.115.0"
   },
   "dependencies": {},
   "engines": {


### PR DESCRIPTION
### Changed

- Upgraded Node binary reference from `12.16` to `v16.13.2` in `.nvmrc`
- `LICENSE` edits
- `README.md` edits
- Beautified `src/helpers/index.js`
- Beautified `src/index.js`
- Beautified `examples/ply-model-to-png.js`
- NPM package upgrades:
  - chai ^4.2.0 → ^4.3.4
  - eslint ^7.1.0 → ^8.6.0
  - mocha ^7.2.0 → ^9.1.3
  - pngjs ^4.0.0 → ^6.0.0
  - three ^0.115.0 → ^0.125.0